### PR TITLE
Fixes OB bug

### DIFF
--- a/code/modules/cm_marines/orbital_cannon.dm
+++ b/code/modules/cm_marines/orbital_cannon.dm
@@ -141,6 +141,10 @@ var/obj/structure/ship_rail_gun/almayer_rail_gun
 /obj/structure/orbital_cannon/proc/chamber_payload(mob/user)
 	set waitfor = 0
 
+	if(!loaded_tray)
+			to_chat(user, "You need to load the tray to chamber it.")
+		return
+	
 	if(ob_cannon_busy)
 		return
 


### PR DESCRIPTION
## About The Pull Request
This fixes a bug where you can chamber the OB tray without loading the tray causing it to not use ammo or start the timer allowing you to use the OB as a machine gun.

## Why It's Good For The Game

Stops machine gun OB

## Changelog
:cl:
fix: Makes the OB not be able to be fired like a machine gun.

